### PR TITLE
feat: Add nativeEnum for Borsh serialization of simple enums

### DIFF
--- a/.changeset/add-native-enum.md
+++ b/.changeset/add-native-enum.md
@@ -1,0 +1,5 @@
+---
+"@zorsh/zorsh": minor
+---
+
+Adds `nativeEnum` builder for serializing TypeScript enums as Rust enums using the variant index.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,43 @@ const PersonSchema = b.struct({
 });
 ```
 
+### Native Enums
+
+Zorsh provides a `nativeEnum` builder for serializing and deserializing simple Rust enums (without associated data) as TypeScript enums. This approach uses the variant index for serialization, ensuring compatibility with how Rust enums are handled in Borsh. It supports TypeScript enums with explicitly assigned numeric values by performing a reverse lookup during serialization.
+
+```typescript
+import { b } from "@zorsh/zorsh";
+
+enum Color {
+  Red,
+  Green,
+  Blue,
+}
+
+const ColorSchema = b.nativeEnum(Color);
+
+// Serialize
+const bytes = ColorSchema.serialize("Green"); // Serializes to [1]
+
+// Deserialize
+const color = ColorSchema.deserialize(new Uint8Array([1])); // "Green"
+```
+
+Enums with explicit values:
+```typescript
+enum HttpCodes {
+ OK = 200,
+ BadRequest = 400,
+ NotFound = 404
+}
+
+const HttpCodesSchema = b.nativeEnum(HttpCodes);
+const bytes = HttpCodesSchema.serialize("NotFound"); // Serializes to [2]
+```
+
 #### Enums
+
+**Note:** The `enum` builder is for Rust-like enums with optional associated data. For simple enums that can be represented as TypeScript enums, use `nativeEnum` instead.
 
 ```typescript
 // Simple enum

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "packageManager": "pnpm@10.3.0",
   "scripts": {
     "build": "tsc",
-    "test": "vitest",
+    "test": "vitest run",
     "lint": "biome check --write .",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
+export { nativeEnum } from "./native-enum"
 export { b, Schema } from "./schema"

--- a/src/native-enum.ts
+++ b/src/native-enum.ts
@@ -1,0 +1,57 @@
+import type { BinaryReader, BinaryWriter } from "./binary-io"
+import { registry } from "./registry"
+import { Schema } from "./schema"
+
+interface NativeEnumOptions {
+  indexMap: Map<number, string>
+  valueMap: Map<string, number>
+}
+
+function createNativeEnumOptions<T extends Record<string, unknown>>(
+  typescriptEnum: T,
+): NativeEnumOptions {
+  const indexMap = new Map<number, string>()
+  const valueMap = new Map<string, number>()
+
+  // Iterate over enum members to build reverse lookup maps.
+  for (const key in typescriptEnum) {
+    if (Number.isNaN(Number(key))) {
+      // Filter out numeric keys (reverse mappings)
+      const value = typescriptEnum[key] as number | string
+      if (typeof value === "number") {
+        indexMap.set(value, key)
+        valueMap.set(key, value)
+      }
+    }
+  }
+
+  return { indexMap, valueMap }
+}
+
+export const nativeEnum = <T extends Record<string, string | number>>(
+  typescriptEnum: T,
+): Schema<keyof T, "nativeEnum"> => {
+  const options = createNativeEnumOptions(typescriptEnum)
+  return new Schema("nativeEnum", options, registry)
+}
+
+// Type handler for native enums
+registry.register<string, NativeEnumOptions>("nativeEnum", {
+  write: (writer: BinaryWriter, value: string, options?: NativeEnumOptions) => {
+    if (!options) throw new Error("Missing options for nativeEnum")
+    const index = options.valueMap.get(value)
+    if (index === undefined) {
+      throw new Error(`Invalid enum variant: ${value}`)
+    }
+    writer.writeUint8(index)
+  },
+  read: (reader: BinaryReader, options?: NativeEnumOptions) => {
+    if (!options) throw new Error("Missing options for nativeEnum")
+    const index = reader.readUint8()
+    const variant = options.indexMap.get(index)
+    if (variant === undefined) {
+      throw new Error(`Invalid enum index: ${index}`)
+    }
+    return variant
+  },
+})

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,4 +1,5 @@
 import { BinaryReader, BinaryWriter } from "./binary-io"
+import { nativeEnum } from "./native-enum"
 import { type TypeRegistry, registry } from "./registry"
 import type { VecType } from "./types"
 
@@ -131,6 +132,8 @@ export const b = {
 
     return new Schema("enum", { variants: variantArray }, registry)
   },
+
+  nativeEnum: nativeEnum,
 
   // Complex types
   struct: <T extends Record<string, Schema<unknown>>>(

--- a/test/native-enum.test.ts
+++ b/test/native-enum.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { BinaryWriter } from "../src/binary-io"
+import { nativeEnum } from "../src/native-enum"
+
+describe("Native Enum Serialization/Deserialization", () => {
+  it("should serialize and deserialize a simple enum", () => {
+    enum TestEnum {
+      A = 0,
+      B = 1,
+      C = 2,
+    }
+
+    const schema = nativeEnum(TestEnum)
+    const serializedA = schema.serialize("A")
+    const deserializedA = schema.deserialize(serializedA)
+    expect(deserializedA).toBe("A")
+
+    const serializedB = schema.serialize("B")
+    const deserializedB = schema.deserialize(serializedB)
+    expect(deserializedB).toBe("B")
+
+    const serializedC = schema.serialize("C")
+    const deserializedC = schema.deserialize(serializedC)
+    expect(deserializedC).toBe("C")
+  })
+
+  it("should serialize and deserialize an enum with explicit values", () => {
+    enum TestEnum {
+      A = 10,
+      B = 20,
+      C = 30,
+    }
+
+    const schema = nativeEnum(TestEnum)
+    const serializedA = schema.serialize("A")
+    const deserializedA = schema.deserialize(serializedA)
+    expect(deserializedA).toBe("A")
+
+    const serializedB = schema.serialize("B")
+    const deserializedB = schema.deserialize(serializedB)
+    expect(deserializedB).toBe("B")
+
+    const serializedC = schema.serialize("C")
+    const deserializedC = schema.deserialize(serializedC)
+    expect(deserializedC).toBe("C")
+  })
+
+  it("should handle out-of-order explicit values", () => {
+    enum TestEnum {
+      A = 5,
+      B = 1,
+      C = 10,
+    }
+    const schema = nativeEnum(TestEnum)
+
+    const serializedA = schema.serialize("A")
+    const deserializedA = schema.deserialize(serializedA)
+    expect(deserializedA).toBe("A")
+
+    const serializedB = schema.serialize("B")
+    const deserializedB = schema.deserialize(serializedB)
+    expect(deserializedB).toBe("B")
+
+    const serializedC = schema.serialize("C")
+    const deserializedC = schema.deserialize(serializedC)
+    expect(deserializedC).toBe("C")
+  })
+
+  it("should throw an error for invalid enum values during serialization", () => {
+    enum TestEnum {
+      A = 0,
+      B = 1,
+      C = 2,
+    }
+    const schema = nativeEnum(TestEnum)
+
+    expect(() => schema.serialize("D" as never)).toThrowError("Invalid enum variant: D")
+  })
+
+  it("should throw an error for invalid enum index during deserialization", () => {
+    enum TestEnum {
+      A = 0,
+      B = 1,
+      C = 2,
+    }
+
+    const schema = nativeEnum(TestEnum)
+    const writer = new BinaryWriter()
+    writer.writeUint8(10) // Invalid index
+    const invalidBuffer = writer.getBuffer()
+
+    expect(() => schema.deserialize(invalidBuffer)).toThrowError("Invalid enum index: 10")
+  })
+})


### PR DESCRIPTION
- **Motivation:** The existing `enum` builder is designed for Rust-like enums with optional associated data. This doesn't align with how simple Rust enums are typically represented in TypeScript (as native enums). The lack of support for native TypeScript enums was causing an impedance mismatch.
- **Impact**: Adds a new feature that enables seamless serialization/deserialization of native TypeScript enums, improving interoperability with Rust codebases using Borsh, without impacting existing functionality. This addresses issue #11.