### PR TITLE
Add TypeScript Native Enum Support

### DIFF
--- a/.changeset/blue-snakes-love.md
+++ b/.changeset/blue-snakes-love.md
@@ -1,0 +1,5 @@
+---
+"@zorsh/zorsh": minor
+---
+
+Add support for TypeScript native enums via the new `b.nativeEnum()` function

--- a/README.md
+++ b/README.md
@@ -126,7 +126,41 @@ const PersonSchema = b.struct({
 });
 ```
 
-#### Enums
+#### Native TypeScript Enums
+
+```typescript
+// Define a TypeScript enum
+enum Status {
+  Idle,
+  Running,
+  Paused,
+  Completed,
+  Failed
+}
+
+// Create a schema for the enum
+const schema = b.nativeEnum(Status);
+
+// Use it directly with your TypeScript enum
+const value = Status.Running;
+const bytes = schema.serialize(value);
+const decoded = schema.deserialize(bytes);
+```
+
+Both numeric and string enums are supported:
+
+```typescript
+// String enum
+enum Color {
+  Red = "RED",
+  Green = "GREEN",
+  Blue = "BLUE"
+}
+
+const colorSchema = b.nativeEnum(Color);
+```
+
+#### Enums with Data
 
 ```typescript
 // Simple enum

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { b, Schema } from "./schema"
+export type { EnumLike, EnumValueType } from "./types"

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,3 +38,18 @@ export type VecType<T> = T extends Schema<unknown, infer Type>
 export type TypeOf<T extends Schema<unknown, string>> = T extends Schema<infer U, string>
   ? U
   : never
+
+/**
+ * Represents a TypeScript enum type.
+ * This interface is used for type constraints in the nativeEnum function.
+ */
+export interface EnumLike {
+  [key: string]: string | number
+  [numericKey: number]: string
+}
+
+/**
+ * Gets the union type of all possible values in an enum.
+ * For example, if the enum is { A = 'a', B = 1 }, then EnumValueType<typeof MyEnum> would be 'a' | 1.
+ */
+export type EnumValueType<T> = T[keyof T]

--- a/test/enum-integration.test.ts
+++ b/test/enum-integration.test.ts
@@ -1,0 +1,144 @@
+// test/enum-integration.test.ts
+import { describe, expect, test } from "vitest"
+import { b } from "../src/schema"
+
+describe("Native Enum Integration with Borsh Enums", () => {
+  // This is a TypeScript native enum representing status
+  enum Status {
+    Idle = 0,
+    Running = 1,
+    Paused = 2,
+    Completed = 3,
+    Failed = 4,
+  }
+
+  // This is a more complex Borsh enum that may contain data
+  // (similar to how Rust enums can have fields)
+  const ResultSchema = b.enum({
+    Success: b.struct({
+      data: b.string(),
+      timestamp: b.u64(),
+    }),
+    Failure: b.struct({
+      error: b.string(),
+      code: b.u16(),
+    }),
+  })
+
+  // Let's define a top-level schema that uses both enum types
+  const TaskSchema = b.struct({
+    id: b.string(),
+    status: b.nativeEnum(Status),
+    result: b.option(ResultSchema),
+    metadata: b.hashMap(b.string(), b.string()),
+  })
+
+  type Task = b.infer<typeof TaskSchema>
+
+  test("mixed enum types in complex schema", () => {
+    // Create a task object
+    const task: Task = {
+      id: "task-123",
+      status: Status.Running,
+      result: null, // No result yet
+      metadata: new Map([
+        ["owner", "alice"],
+        ["priority", "high"],
+      ]),
+    }
+
+    // Serialize and deserialize
+    const serialized = TaskSchema.serialize(task)
+    const deserialized = TaskSchema.deserialize(serialized)
+
+    // Verify
+    expect(deserialized).toEqual(task)
+    expect(deserialized.status).toBe(Status.Running)
+
+    // Now add a successful result and try again
+    const taskWithResult: Task = {
+      ...task,
+      status: Status.Completed,
+      result: {
+        Success: {
+          data: "Completed successfully",
+          timestamp: BigInt(1678886400000),
+        },
+      },
+    }
+
+    const serialized2 = TaskSchema.serialize(taskWithResult)
+    const deserialized2 = TaskSchema.deserialize(serialized2)
+
+    expect(deserialized2).toEqual(taskWithResult)
+    expect(deserialized2.status).toBe(Status.Completed)
+    expect(deserialized2.result).toEqual(taskWithResult.result)
+  })
+
+  test("enum round trip with both types", () => {
+    // Create a task with a failure result
+    const failedTask: Task = {
+      id: "task-456",
+      status: Status.Failed,
+      result: {
+        Failure: {
+          error: "Resource not found",
+          code: 404,
+        },
+      },
+      metadata: new Map([
+        ["owner", "bob"],
+        ["retry", "false"],
+      ]),
+    }
+
+    // Serialize and deserialize
+    const serialized = TaskSchema.serialize(failedTask)
+    const deserialized = TaskSchema.deserialize(serialized)
+
+    // Verify
+    expect(deserialized).toEqual(failedTask)
+    expect(deserialized.status).toBe(Status.Failed)
+    expect(deserialized.result).toEqual(failedTask.result)
+  })
+
+  test("comparing binary representation of native enum vs borsh enum", () => {
+    // Define comparable enums with both approaches
+    enum StatusEnum {
+      Active = 0,
+      Inactive = 1,
+      Pending = 2,
+    }
+
+    const BorshStatusEnum = b.enum({
+      Active: b.unit(),
+      Inactive: b.unit(),
+      Pending: b.unit(),
+    })
+
+    const nativeSchema = b.nativeEnum(StatusEnum)
+
+    // Test serializing values
+    const nativeActive = nativeSchema.serialize(StatusEnum.Active)
+    const nativeInactive = nativeSchema.serialize(StatusEnum.Inactive)
+    const nativePending = nativeSchema.serialize(StatusEnum.Pending)
+
+    const borshActive = BorshStatusEnum.serialize({ Active: {} })
+    const borshInactive = BorshStatusEnum.serialize({ Inactive: {} })
+    const borshPending = BorshStatusEnum.serialize({ Pending: {} })
+
+    // Both should serialize to single-byte values representing the variant index
+    expect(nativeActive.length).toBe(1)
+    expect(borshActive.length).toBe(1)
+
+    // And the index values should match
+    expect(nativeActive[0]).toBe(borshActive[0]) // Both should be 0
+    expect(nativeInactive[0]).toBe(borshInactive[0]) // Both should be 1
+    expect(nativePending[0]).toBe(borshPending[0]) // Both should be 2
+
+    // Ensure consistency with deserializing
+    expect(nativeSchema.deserialize(nativeActive)).toBe(StatusEnum.Active)
+    expect(nativeSchema.deserialize(nativeInactive)).toBe(StatusEnum.Inactive)
+    expect(nativeSchema.deserialize(nativePending)).toBe(StatusEnum.Pending)
+  })
+})

--- a/test/native-enum.test.ts
+++ b/test/native-enum.test.ts
@@ -1,0 +1,180 @@
+// test/native-enum.test.ts
+import { describe, expect, test } from "vitest"
+import { b } from "../src/schema"
+import type { EnumLike } from "../src/types"
+
+describe("Native TypeScript Enum Support", () => {
+  // Test numeric enum (default)
+  enum NumericEnum {
+    Zero = 0, // 0
+    One = 1, // 1
+    Two = 2, // 2
+    Three = 3, // 3
+  }
+
+  // Test explicit numeric enum with non-sequential values
+  enum ExplicitNumericEnum {
+    Twenty = 20,
+    Thirty = 30,
+    Fifty = 50,
+  }
+
+  // Test string enum
+  enum StringEnum {
+    Red = "RED",
+    Green = "GREEN",
+    Blue = "BLUE",
+  }
+
+  // Test heterogeneous enum
+  const HeterogeneousObj = {
+    String: "string-value",
+    Number: 42,
+    // This is not supported, but we're testing to make sure we handle it properly
+  }
+
+  test("numeric enum serialization/deserialization", () => {
+    const schema = b.nativeEnum(NumericEnum)
+
+    // Test all variants
+    const testValues = [NumericEnum.Zero, NumericEnum.One, NumericEnum.Two, NumericEnum.Three]
+
+    for (const value of testValues) {
+      const serialized = schema.serialize(value)
+      const deserialized = schema.deserialize(serialized)
+
+      expect(deserialized).toBe(value)
+      // Should be a single byte for these simple enums
+      expect(serialized.length).toBe(1)
+
+      // For numeric enums, the serialized value should match the enum index, not the value
+      // For example, NumericEnum.Two (value 2) should serialize as index 2 -> [2]
+      // NumericEnum.Zero has index 0, One has index 1, etc.
+      const valueAsNumber = value as number
+      expect(serialized[0]).toBe(valueAsNumber)
+    }
+  })
+
+  test("explicit numeric enum serialization/deserialization", () => {
+    const schema = b.nativeEnum(ExplicitNumericEnum)
+
+    // Test all variants
+    const testValues = [
+      ExplicitNumericEnum.Twenty,
+      ExplicitNumericEnum.Thirty,
+      ExplicitNumericEnum.Fifty,
+    ]
+
+    for (const value of testValues) {
+      const serialized = schema.serialize(value)
+      const deserialized = schema.deserialize(serialized)
+
+      expect(deserialized).toBe(value)
+      // Should be a single byte because we're serializing the variant index (0, 1, 2)
+      // NOT the value (20, 30, 50)
+      expect(serialized.length).toBe(1)
+
+      // The index for Twenty is 0, Thirty is 1, Fifty is 2 - regardless of their values
+      let expectedIndex = -1
+      if (value === ExplicitNumericEnum.Twenty) expectedIndex = 0
+      else if (value === ExplicitNumericEnum.Thirty) expectedIndex = 1
+      else if (value === ExplicitNumericEnum.Fifty) expectedIndex = 2
+
+      expect(serialized[0]).toBe(expectedIndex)
+    }
+  })
+
+  test("string enum serialization/deserialization", () => {
+    const schema = b.nativeEnum(StringEnum)
+
+    // Test all variants
+    const testValues = [StringEnum.Red, StringEnum.Green, StringEnum.Blue]
+
+    for (const value of testValues) {
+      const serialized = schema.serialize(value)
+      const deserialized = schema.deserialize(serialized)
+
+      expect(deserialized).toBe(value)
+      // Should be a single byte for these simple enums
+      expect(serialized.length).toBe(1)
+
+      // The serialized value should be the index: Red=0, Green=1, Blue=2
+      let expectedIndex = -1
+      if (value === StringEnum.Red) expectedIndex = 0
+      else if (value === StringEnum.Green) expectedIndex = 1
+      else if (value === StringEnum.Blue) expectedIndex = 2
+
+      expect(serialized[0]).toBe(expectedIndex)
+    }
+  })
+
+  test("invalid enum values are rejected", () => {
+    const schema = b.nativeEnum(NumericEnum)
+
+    // @ts-expect-error - Invalid enum value
+    expect(() => schema.serialize(99)).toThrow()
+    // @ts-expect-error - Invalid enum value
+    expect(() => schema.serialize("invalid")).toThrow()
+  })
+
+  test("mixed string/numeric enums should throw", () => {
+    expect(() => b.nativeEnum(HeterogeneousObj)).toThrow()
+  })
+
+  test("enums with more than 255 variants should error", () => {
+    // Create a large enum with more than 255 variants (just mock the object)
+    // Create enum as a class to bypass index signature compatibility issues
+    class LargeEnum implements EnumLike {
+      [key: string]: string | number
+      [numericKey: number]: string
+    }
+
+    const largeEnum = new LargeEnum()
+    for (let i = 0; i < 256; i++) {
+      largeEnum[`Variant${i}`] = i
+      // Add reverse mapping to make it conform to EnumLike interface
+      largeEnum[i] = `Variant${i}`
+    }
+
+    expect(() => b.nativeEnum(largeEnum)).toThrow()
+  })
+
+  test("type inference works correctly", () => {
+    const schema = b.nativeEnum(StringEnum)
+
+    // Type checking - this is compile-time verification
+    type Expected = StringEnum
+    type Actual = b.infer<typeof schema>
+
+    // This assignment would fail if types don't match
+    const _typecheck: Expected = {} as Actual
+
+    // Make sure TypeScript sees StringEnum.Red as assignable to the inferred type
+    const value: Actual = StringEnum.Red
+    expect(value).toBe(StringEnum.Red)
+  })
+
+  test("enums in complex structures", () => {
+    // Define a schema with an enum field
+    const PlayerSchema = b.struct({
+      name: b.string(),
+      status: b.nativeEnum(NumericEnum),
+      color: b.nativeEnum(StringEnum),
+    })
+
+    type Player = b.infer<typeof PlayerSchema>
+
+    const player: Player = {
+      name: "Alice",
+      status: NumericEnum.Two,
+      color: StringEnum.Blue,
+    }
+
+    const serialized = PlayerSchema.serialize(player)
+    const deserialized = PlayerSchema.deserialize(serialized)
+
+    expect(deserialized).toEqual(player)
+    expect(deserialized.status).toBe(NumericEnum.Two)
+    expect(deserialized.color).toBe(StringEnum.Blue)
+  })
+})


### PR DESCRIPTION
This PR adds support for TypeScript's native enums through a new `b.nativeEnum()` function. This makes Zorsh more ergonomic for TypeScript developers by allowing them to use familiar enum syntax rather than the more verbose Borsh-style enum builder.

## Features

- Added `b.nativeEnum()` function that accepts TypeScript enums
- Support for both numeric and string enums
- Full type inference (`b.infer<typeof schema>` correctly resolves to the enum type)
- Binary format compatible with Borsh spec (enums serialized as u8 variant indices)
- Comprehensive tests for all enum types and edge cases

## Example

```typescript
// Define a TypeScript enum
enum Status {
  Idle,
  Running,
  Paused,
  Completed,
  Failed
}

// Create a schema for the enum
const schema = b.nativeEnum(Status);

// Use it directly with TypeScript enum values
const status = Status.Running;
const bytes = schema.serialize(status);
const decoded = schema.deserialize(bytes);
```

## Testing

- Added `native-enum.test.ts` with tests for all enum types
- Added `enum-integration.test.ts` to verify interoperability with other schema types
- Added tests for edge cases (invalid values, mixed types, max variants)

## Documentation

- Updated README.md with examples and usage information
- Added clear error messages for common misuses

Closes #11