### PR TITLE
Fix type inference for enum types in schema definitions

### DIFF
--- a/.changeset/eight-days-boil.md
+++ b/.changeset/eight-days-boil.md
@@ -1,0 +1,5 @@
+---
+"@zorsh/zorsh": patch
+---
+
+fix(enum): use direct enum types instead of value unions

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { b, Schema } from "./schema"
-export type { EnumLike, EnumValueType } from "./types"
+export type { EnumLike } from "./types"

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,6 +1,6 @@
 import { BinaryReader, BinaryWriter } from "./binary-io"
 import { type TypeRegistry, registry } from "./registry"
-import type { EnumLike, EnumValueType, VecType } from "./types"
+import type { EnumLike, VecType } from "./types"
 
 export class Schema<T, Type extends string = string> {
   constructor(
@@ -26,13 +26,6 @@ export class Schema<T, Type extends string = string> {
 // First declare the namespace type (for type-level stuff)
 export namespace b {
   export type infer<T extends Schema<unknown>> = T extends Schema<infer U> ? U : never
-
-  /**
-   * Helper type for inferring the value type of a TypeScript enum.
-   * Used internally by the nativeEnum function.
-   * @internal
-   */
-  export type inferEnum<T> = T extends EnumLike ? EnumValueType<T> : never
 }
 
 // Builder API
@@ -166,7 +159,7 @@ export const b = {
   },
 
   // Native TypeScript enum
-  nativeEnum: <T extends EnumLike>(enumObj: T): Schema<b.inferEnum<T>, "nativeEnum"> => {
+  nativeEnum: <T extends EnumLike>(enumObj: T): Schema<T[keyof T], "nativeEnum"> => {
     // First, filter out numeric keys that TypeScript adds to enums
     const enumEntries = Object.entries(enumObj).filter(
       ([key]) => typeof key === "string" && Number.isNaN(Number(key)),

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,9 +47,3 @@ export interface EnumLike {
   [key: string]: string | number
   [numericKey: number]: string
 }
-
-/**
- * Gets the union type of all possible values in an enum.
- * For example, if the enum is { A = 'a', B = 1 }, then EnumValueType<typeof MyEnum> would be 'a' | 1.
- */
-export type EnumValueType<T> = T[keyof T]


### PR DESCRIPTION
## Purpose/Motivation
When using `b.nativeEnum()` with TypeScript enums in struct schemas, the type inference was returning union types rather than the enum type itself. This made it more difficult to work with the resulting types since you couldn't directly use the enum in a type-safe manner.

## Changes
- Fix type inference for native TypeScript enums so that `b.infer<typeof Schema>` returns the actual enum type (e.g., `ChainKind`) rather than a value union type (`EnumValueType<typeof ChainKind>`), allowing for proper type checking and IDE support when working with enum values