### PR TITLE
feat: add b.lazy() for recursive/self-referential schemas

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -534,3 +534,32 @@ registry.register<
     return value
   },
 })
+
+// Add lazy handler - enables recursive/self-referential schemas
+interface LazyOptions {
+  factory: () => { type: string; options: unknown }
+  _cached?: { type: string; options: unknown }
+}
+
+function resolveLazy(options: LazyOptions): { type: string; options: unknown } {
+  if (!options._cached) {
+    const resolved = options.factory()
+    options._cached = { type: resolved.type, options: resolved.options }
+  }
+  return options._cached
+}
+
+registry.register<unknown, LazyOptions>("lazy", {
+  write: (writer, value, options) => {
+    if (!options) return
+    const resolved = resolveLazy(options)
+    const handler = registry.getHandler(resolved.type)
+    handler.write(writer, value, resolved.options)
+  },
+  read: (reader, options) => {
+    if (!options) return undefined
+    const resolved = resolveLazy(options)
+    const handler = registry.getHandler(resolved.type)
+    return handler.read(reader, resolved.options)
+  },
+})

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -162,6 +162,11 @@ export const b = {
     return new Schema("tuple", types, registry)
   },
 
+  // Lazy schema for recursive/self-referential types
+  lazy: <T>(factory: () => Schema<T>): Schema<T> => {
+    return new Schema("lazy", { factory }, registry)
+  },
+
   // Native TypeScript enum
   nativeEnum: <T extends EnumLike>(enumObj: T): Schema<T[keyof T], "nativeEnum"> => {
     // First, filter out numeric keys that TypeScript adds to enums

--- a/test/lazy.test.ts
+++ b/test/lazy.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from "vitest"
+import { type Schema, b } from "../src"
+
+describe("b.lazy() - recursive schemas", () => {
+  it("should roundtrip a simple recursive tree", () => {
+    // Binary tree: each node has a value and optional left/right children
+    const TreeNodeSchema: Schema<unknown> = b.enum({
+      Leaf: b.struct({ value: b.u32() }),
+      Branch: b.struct({
+        value: b.u32(),
+        left: b.lazy(() => TreeNodeSchema),
+        right: b.lazy(() => TreeNodeSchema),
+      }),
+    })
+
+    const tree = {
+      Branch: {
+        value: 1,
+        left: { Leaf: { value: 2 } },
+        right: {
+          Branch: {
+            value: 3,
+            left: { Leaf: { value: 4 } },
+            right: { Leaf: { value: 5 } },
+          },
+        },
+      },
+    }
+
+    const bytes = TreeNodeSchema.serialize(tree)
+    const deserialized = TreeNodeSchema.deserialize(bytes)
+    expect(deserialized).toEqual(tree)
+  })
+
+  it("should roundtrip recursive vec (list of self)", () => {
+    // Like ProposalAction::BatchActions(Vec<ProposalAction>)
+    const ActionSchema: Schema<unknown> = b.enum({
+      Simple: b.u32(),
+      Batch: b.vec(b.lazy(() => ActionSchema)),
+    })
+
+    const action = {
+      Batch: [{ Simple: 1 }, { Simple: 2 }, { Batch: [{ Simple: 3 }] }],
+    }
+
+    const bytes = ActionSchema.serialize(action)
+    const deserialized = ActionSchema.deserialize(bytes)
+    expect(deserialized).toEqual(action)
+  })
+
+  it("should roundtrip recursive option (optional self)", () => {
+    // Linked list: each node has a value and an optional next node
+    const ListNodeSchema: Schema<unknown> = b.struct({
+      value: b.u32(),
+      next: b.option(b.lazy(() => ListNodeSchema)),
+    })
+
+    const list = {
+      value: 1,
+      next: {
+        value: 2,
+        next: {
+          value: 3,
+          next: null,
+        },
+      },
+    }
+
+    const bytes = ListNodeSchema.serialize(list)
+    const deserialized = ListNodeSchema.deserialize(bytes)
+    expect(deserialized).toEqual(list)
+  })
+
+  it("should handle deeply nested recursion", () => {
+    const NodeSchema: Schema<unknown> = b.enum({
+      Leaf: b.u32(),
+      Branch: b.vec(b.lazy(() => NodeSchema)),
+    })
+
+    // 4 levels deep
+    const deep = {
+      Branch: [
+        {
+          Branch: [
+            {
+              Branch: [{ Branch: [{ Leaf: 42 }] }],
+            },
+          ],
+        },
+      ],
+    }
+
+    const bytes = NodeSchema.serialize(deep)
+    const deserialized = NodeSchema.deserialize(bytes)
+    expect(deserialized).toEqual(deep)
+  })
+
+  it("should handle mutual recursion via lazy", () => {
+    // Expression / Statement mutual recursion
+    const ExprSchema: Schema<unknown> = b.enum({
+      Literal: b.u32(),
+      Block: b.vec(b.lazy(() => StmtSchema)),
+    })
+
+    const StmtSchema: Schema<unknown> = b.enum({
+      ExprStmt: b.lazy(() => ExprSchema),
+      Return: b.lazy(() => ExprSchema),
+    })
+
+    const program = {
+      ExprStmt: {
+        Block: [{ Return: { Literal: 42 } }],
+      },
+    }
+
+    const bytes = StmtSchema.serialize(program)
+    const deserialized = StmtSchema.deserialize(bytes)
+    expect(deserialized).toEqual(program)
+  })
+
+  it("should work with lazy inside struct fields", () => {
+    const CategorySchema: Schema<unknown> = b.struct({
+      name: b.string(),
+      children: b.vec(b.lazy(() => CategorySchema)),
+    })
+
+    const category = {
+      name: "root",
+      children: [
+        {
+          name: "child1",
+          children: [{ name: "grandchild", children: [] }],
+        },
+        { name: "child2", children: [] },
+      ],
+    }
+
+    const bytes = CategorySchema.serialize(category)
+    const deserialized = CategorySchema.deserialize(bytes)
+    expect(deserialized).toEqual(category)
+  })
+
+  it("should work with lazy inside hashMap values", () => {
+    const TreeSchema: Schema<unknown> = b.enum({
+      Leaf: b.string(),
+      Node: b.hashMap(
+        b.string(),
+        b.lazy(() => TreeSchema),
+      ),
+    })
+
+    const tree = {
+      Node: new Map([
+        ["left", { Leaf: "hello" }],
+        ["right", { Node: new Map([["inner", { Leaf: "world" }]]) }],
+      ]),
+    }
+
+    const bytes = TreeSchema.serialize(tree)
+    const deserialized = TreeSchema.deserialize(bytes)
+    expect(deserialized).toEqual(tree)
+  })
+
+  it("should cache the factory result", () => {
+    let callCount = 0
+    const schema: Schema<unknown> = b.struct({
+      value: b.u32(),
+      next: b.option(
+        b.lazy(() => {
+          callCount++
+          return schema
+        }),
+      ),
+    })
+
+    const data = { value: 1, next: { value: 2, next: null } }
+
+    // Serialize and deserialize multiple times
+    schema.deserialize(schema.serialize(data))
+    schema.deserialize(schema.serialize(data))
+
+    // Factory should only be called once due to caching
+    expect(callCount).toBe(1)
+  })
+
+  it("should handle lazy with unit variants", () => {
+    const ConditionSchema: Schema<unknown> = b.enum({
+      True: b.unit(),
+      False: b.unit(),
+      And: b.vec(b.lazy(() => ConditionSchema)),
+      Or: b.vec(b.lazy(() => ConditionSchema)),
+      Not: b.lazy(() => ConditionSchema),
+    })
+
+    const condition = {
+      And: [{ True: {} }, { Or: [{ False: {} }, { Not: { True: {} } }] }],
+    }
+
+    const bytes = ConditionSchema.serialize(condition)
+    const deserialized = ConditionSchema.deserialize(bytes)
+    expect(deserialized).toEqual(condition)
+  })
+
+  it("should produce identical bytes to non-lazy equivalent for non-recursive data", () => {
+    // Verify that b.lazy(() => X) produces the same bytes as X directly
+    const directSchema = b.struct({
+      name: b.string(),
+      value: b.u32(),
+    })
+
+    const lazySchema = b.struct({
+      name: b.lazy(() => b.string()),
+      value: b.lazy(() => b.u32()),
+    })
+
+    const data = { name: "test", value: 42 }
+
+    const directBytes = directSchema.serialize(data)
+    const lazyBytes = lazySchema.serialize(data)
+
+    expect(lazyBytes).toEqual(directBytes)
+
+    const directResult = directSchema.deserialize(directBytes)
+    const lazyResult = lazySchema.deserialize(lazyBytes)
+
+    expect(lazyResult).toEqual(directResult)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `b.lazy(factory)` builder method that defers schema resolution until serialization/deserialization time, enabling recursive and self-referential type definitions
- Registers a `"lazy"` handler in the type registry that resolves and caches the factory result on first use
- Adds 10 comprehensive tests covering: recursive trees, recursive vecs, recursive options, deeply nested recursion (4 levels), mutual recursion, lazy in struct fields, lazy in hashMap values, factory caching verification, recursive conditions with unit variants, and byte equivalence with direct schemas

## Motivation

Recursive types like trees, linked lists, and Borsh enums with self-referential variants (e.g. `ProposalAction::BatchActions(Vec<ProposalAction>)`) could not be represented prior to this change. The eager `{type, options}` destructuring in builders like `b.vec()` and `b.enum()` meant the schema had to be fully constructed at definition time — impossible for self-references.

## How It Works

`b.lazy(() => schema)` creates a `Schema` with `type="lazy"` and stores the factory function in `options`. When a parent handler (vec, enum, struct, etc.) captures it, it stores `elementType="lazy"` and `elementOptions={factory}`. At serialize/deserialize time, the lazy handler calls the factory to get the real schema, caches the result, and delegates to the resolved handler.

```typescript
import { b, Schema } from "@zorsh/zorsh"

// Recursive enum — like Rust's Box<Self> / Vec<Self> patterns
const ActionSchema: Schema<unknown> = b.enum({
  Simple: b.u32(),
  Batch: b.vec(b.lazy(() => ActionSchema)),
})

// Linked list via recursive option
const ListSchema: Schema<unknown> = b.struct({
  value: b.u32(),
  next: b.option(b.lazy(() => ListSchema)),
})

// Mutual recursion
const ExprSchema: Schema<unknown> = b.enum({
  Literal: b.u32(),
  Block: b.vec(b.lazy(() => StmtSchema)),
})
const StmtSchema: Schema<unknown> = b.enum({
  Expr: b.lazy(() => ExprSchema),
  Return: b.lazy(() => ExprSchema),
})
```

> **Note:** Recursive schemas require an explicit `Schema<unknown>` type annotation because TypeScript cannot infer the type of a self-referencing `const`. This is the same pattern as Zod's `z.lazy()`.

## Changes

| File | Change |
|---|---|
| `src/schema.ts` | Add `b.lazy<T>(factory: () => Schema<T>): Schema<T>` builder (+5 lines) |
| `src/registry.ts` | Register `"lazy"` handler with cached resolution (+29 lines) |
| `test/lazy.test.ts` | 10 tests covering all recursive patterns (+228 lines) |