### PR TITLE
feat!: make b.vec() return plain arrays for numeric types

### DIFF
--- a/.changeset/vec-plain-arrays.md
+++ b/.changeset/vec-plain-arrays.md
@@ -1,0 +1,5 @@
+---
+"@zorsh/zorsh": major
+---
+
+`b.vec()` with numeric element types now returns `Array<number>` / `Array<bigint>` instead of typed arrays (`Uint8Array`, `Uint32Array`, etc.). `b.bytes()` is unchanged and still returns `Uint8Array` for raw binary data. Wire format is unchanged.

--- a/.changeset/vec-plain-arrays.md
+++ b/.changeset/vec-plain-arrays.md
@@ -1,5 +1,5 @@
 ---
-"@zorsh/zorsh": major
+"@zorsh/zorsh": minor
 ---
 
 `b.vec()` with numeric element types now returns `Array<number>` / `Array<bigint>` instead of typed arrays (`Uint8Array`, `Uint32Array`, etc.). `b.bytes()` is unchanged and still returns `Uint8Array` for raw binary data. Wire format is unchanged.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ const schema = b.struct({
 type T = b.infer<typeof schema>;
 // {
 //   id: string
-//   data: Uint8Array | null
+//   data: number[] | null
 //   metadata: Map<string, bigint>
 // }
 ```

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,4 @@
 import type { BinaryReader, BinaryWriter } from "./binary-io"
-import type { TypedArrayType } from "./types"
 
 export interface TypeHandler<TValue, TOptions = unknown> {
   write: (writer: BinaryWriter, value: TValue, options?: TOptions) => void
@@ -197,24 +196,17 @@ interface VecOptions<T> {
   elementOptions: T
 }
 
-registry.register<unknown[] | TypedArrayType, VecOptions<unknown>>("vec", {
+registry.register<unknown[], VecOptions<unknown>>("vec", {
   write: (writer, value, options) => {
     if (!options) return
     const { elementType, elementOptions } = options
 
-    // Handle TypedArrays and regular arrays
-    const length = ArrayBuffer.isView(value) ? value.length : value.length
+    const length = value.length
     writer.writeUint32(length)
 
     const handler = registry.getHandler(elementType)
-    if (ArrayBuffer.isView(value)) {
-      for (let i = 0; i < length; i++) {
-        handler.write(writer, value[i], elementOptions)
-      }
-    } else {
-      for (const item of value) {
-        handler.write(writer, item, elementOptions)
-      }
+    for (const item of value) {
+      handler.write(writer, item, elementOptions)
     }
   },
   read: (reader, options) => {
@@ -223,32 +215,7 @@ registry.register<unknown[] | TypedArrayType, VecOptions<unknown>>("vec", {
     const length = reader.readUint32()
     const handler = registry.getHandler(elementType)
 
-    // Create array of raw values first
-    const values = Array.from({ length }, () => handler.read(reader, elementOptions))
-
-    // Convert to appropriate TypedArray if needed
-    switch (elementType) {
-      case "u8":
-        return new Uint8Array(values as number[])
-      case "u16":
-        return new Uint16Array(values as number[])
-      case "u32":
-        return new Uint32Array(values as number[])
-      case "i8":
-        return new Int8Array(values as number[])
-      case "i16":
-        return new Int16Array(values as number[])
-      case "i32":
-        return new Int32Array(values as number[])
-      case "i64":
-        return new BigInt64Array(values as bigint[])
-      case "f32":
-        return new Float32Array(values as number[])
-      case "f64":
-        return new Float64Array(values as number[])
-      default:
-        return values
-    }
+    return Array.from({ length }, () => handler.read(reader, elementOptions))
   },
 })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,36 +1,9 @@
 import type { Schema } from "./schema"
 
 /**
- * Maps primitive schema types to their TypedArray types
- */
-type TypedArrayMap = {
-  u8: Uint8Array
-  u16: Uint16Array
-  u32: Uint32Array
-  i8: Int8Array
-  i16: Int16Array
-  i32: Int32Array
-  i64: BigInt64Array
-  f32: Float32Array
-  f64: Float64Array
-}
-
-type NumericTypes = keyof TypedArrayMap
-export type TypedArrayType = TypedArrayMap[NumericTypes]
-
-/**
- * Helper type to determine if a schema should use a TypedArray
- */
-export type IsTypedArraySchema<T> = T extends Schema<unknown, NumericTypes> ? true : false
-
-/**
  * Maps schema types to their appropriate array types
  */
-export type VecType<T> = T extends Schema<unknown, infer Type>
-  ? Type extends keyof TypedArrayMap
-    ? TypedArrayMap[Type]
-    : Array<TypeOf<T>>
-  : never
+export type VecType<T> = T extends Schema<unknown, string> ? Array<TypeOf<T>> : never
 
 /**
  * Extracts the inner type from a Schema

--- a/test/__snapshots__/serialization.test.ts.snap
+++ b/test/__snapshots__/serialization.test.ts.snap
@@ -1,6 +1,353 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
-exports[`complex nested structures > game state example 1`] = `
+exports[`primitive types numeric type u8 1`] = `
+Uint8Array [
+  255,
+]
+`;
+
+exports[`primitive types numeric type u16 1`] = `
+Uint8Array [
+  255,
+  255,
+]
+`;
+
+exports[`primitive types numeric type u32 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types numeric type u64 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types numeric type u128 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types numeric type i8 1`] = `
+Uint8Array [
+  128,
+]
+`;
+
+exports[`primitive types numeric type i16 1`] = `
+Uint8Array [
+  0,
+  128,
+]
+`;
+
+exports[`primitive types numeric type i32 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types numeric type i64 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types numeric type i128 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types numeric type f32 1`] = `
+Uint8Array [
+  0,
+  0,
+  128,
+  60,
+]
+`;
+
+exports[`primitive types numeric type f64 1`] = `
+Uint8Array [
+  24,
+  45,
+  68,
+  84,
+  251,
+  33,
+  9,
+  64,
+]
+`;
+
+exports[`primitive types bool 1`] = `
+Uint8Array [
+  1,
+]
+`;
+
+exports[`primitive types bool 2`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`primitive types string 1`] = `
+Uint8Array [
+  18,
+  0,
+  0,
+  0,
+  72,
+  101,
+  108,
+  108,
+  111,
+  44,
+  32,
+  119,
+  111,
+  114,
+  108,
+  100,
+  33,
+  32,
+  240,
+  159,
+  145,
+  139,
+]
+`;
+
+exports[`primitive types unit 1`] = `Uint8Array []`;
+
+exports[`complex types fixed array 1`] = `
+Uint8Array [
+  1,
+  0,
+  2,
+  0,
+  3,
+  0,
+]
+`;
+
+exports[`complex types dynamic vec 1`] = `
+Uint8Array [
+  5,
+  0,
+  0,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+]
+`;
+
+exports[`complex types option: some value 1`] = `
+Uint8Array [
+  1,
+  5,
+  0,
+  0,
+  0,
+  104,
+  101,
+  108,
+  108,
+  111,
+]
+`;
+
+exports[`complex types option: none value 1`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`complex types hashset 1`] = `
+Uint8Array [
+  3,
+  0,
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  97,
+  1,
+  0,
+  0,
+  0,
+  98,
+  1,
+  0,
+  0,
+  0,
+  99,
+]
+`;
+
+exports[`complex types hashmap 1`] = `
+Uint8Array [
+  2,
+  0,
+  0,
+  0,
+  5,
+  0,
+  0,
+  0,
+  97,
+  108,
+  105,
+  99,
+  101,
+  100,
+  0,
+  0,
+  0,
+  3,
+  0,
+  0,
+  0,
+  98,
+  111,
+  98,
+  200,
+  0,
+  0,
+  0,
+]
+`;
+
+exports[`complex types struct 1`] = `
+Uint8Array [
+  5,
+  0,
+  0,
+  0,
+  97,
+  108,
+  105,
+  99,
+  101,
+  25,
+  3,
+  0,
+  0,
+  0,
+  90,
+  0,
+  95,
+  0,
+  100,
+  0,
+]
+`;
+
+exports[`complex types enum: simple enum 1`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`complex types enum: enum with data - ok 1`] = `
+Uint8Array [
+  0,
+  7,
+  0,
+  0,
+  0,
+  115,
+  117,
+  99,
+  99,
+  101,
+  115,
+  115,
+]
+`;
+
+exports[`complex types enum: enum with data - err 1`] = `
+Uint8Array [
+  1,
+  148,
+  1,
+  9,
+  0,
+  0,
+  0,
+  78,
+  111,
+  116,
+  32,
+  102,
+  111,
+  117,
+  110,
+  100,
+]
+`;
+
+exports[`complex nested structures game state example 1`] = `
 Uint8Array [
   1,
   0,
@@ -118,350 +465,3 @@ Uint8Array [
   73,
 ]
 `;
-
-exports[`complex types > dynamic vec 1`] = `
-Uint8Array [
-  5,
-  0,
-  0,
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-]
-`;
-
-exports[`complex types > enum > enum with data - err 1`] = `
-Uint8Array [
-  1,
-  148,
-  1,
-  9,
-  0,
-  0,
-  0,
-  78,
-  111,
-  116,
-  32,
-  102,
-  111,
-  117,
-  110,
-  100,
-]
-`;
-
-exports[`complex types > enum > enum with data - ok 1`] = `
-Uint8Array [
-  0,
-  7,
-  0,
-  0,
-  0,
-  115,
-  117,
-  99,
-  99,
-  101,
-  115,
-  115,
-]
-`;
-
-exports[`complex types > enum > simple enum 1`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`complex types > fixed array 1`] = `
-Uint8Array [
-  1,
-  0,
-  2,
-  0,
-  3,
-  0,
-]
-`;
-
-exports[`complex types > hashmap 1`] = `
-Uint8Array [
-  2,
-  0,
-  0,
-  0,
-  5,
-  0,
-  0,
-  0,
-  97,
-  108,
-  105,
-  99,
-  101,
-  100,
-  0,
-  0,
-  0,
-  3,
-  0,
-  0,
-  0,
-  98,
-  111,
-  98,
-  200,
-  0,
-  0,
-  0,
-]
-`;
-
-exports[`complex types > hashset 1`] = `
-Uint8Array [
-  3,
-  0,
-  0,
-  0,
-  1,
-  0,
-  0,
-  0,
-  97,
-  1,
-  0,
-  0,
-  0,
-  98,
-  1,
-  0,
-  0,
-  0,
-  99,
-]
-`;
-
-exports[`complex types > option > none value 1`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`complex types > option > some value 1`] = `
-Uint8Array [
-  1,
-  5,
-  0,
-  0,
-  0,
-  104,
-  101,
-  108,
-  108,
-  111,
-]
-`;
-
-exports[`complex types > struct 1`] = `
-Uint8Array [
-  5,
-  0,
-  0,
-  0,
-  97,
-  108,
-  105,
-  99,
-  101,
-  25,
-  3,
-  0,
-  0,
-  0,
-  90,
-  0,
-  95,
-  0,
-  100,
-  0,
-]
-`;
-
-exports[`primitive types > bool 1`] = `
-Uint8Array [
-  1,
-]
-`;
-
-exports[`primitive types > bool 2`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`primitive types > numeric type 'f32' 1`] = `
-Uint8Array [
-  0,
-  0,
-  128,
-  60,
-]
-`;
-
-exports[`primitive types > numeric type 'f64' 1`] = `
-Uint8Array [
-  24,
-  45,
-  68,
-  84,
-  251,
-  33,
-  9,
-  64,
-]
-`;
-
-exports[`primitive types > numeric type 'i8' 1`] = `
-Uint8Array [
-  128,
-]
-`;
-
-exports[`primitive types > numeric type 'i16' 1`] = `
-Uint8Array [
-  0,
-  128,
-]
-`;
-
-exports[`primitive types > numeric type 'i32' 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types > numeric type 'i64' 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types > numeric type 'i128' 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types > numeric type 'u8' 1`] = `
-Uint8Array [
-  255,
-]
-`;
-
-exports[`primitive types > numeric type 'u16' 1`] = `
-Uint8Array [
-  255,
-  255,
-]
-`;
-
-exports[`primitive types > numeric type 'u32' 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types > numeric type 'u64' 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types > numeric type 'u128' 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types > string 1`] = `
-Uint8Array [
-  18,
-  0,
-  0,
-  0,
-  72,
-  101,
-  108,
-  108,
-  111,
-  44,
-  32,
-  119,
-  111,
-  114,
-  108,
-  100,
-  33,
-  32,
-  240,
-  159,
-  145,
-  139,
-]
-`;
-
-exports[`primitive types > unit 1`] = `Uint8Array []`;

--- a/test/__snapshots__/serialization.test.ts.snap
+++ b/test/__snapshots__/serialization.test.ts.snap
@@ -1,353 +1,6 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`primitive types numeric type u8 1`] = `
-Uint8Array [
-  255,
-]
-`;
-
-exports[`primitive types numeric type u16 1`] = `
-Uint8Array [
-  255,
-  255,
-]
-`;
-
-exports[`primitive types numeric type u32 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types numeric type u64 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types numeric type u128 1`] = `
-Uint8Array [
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-  255,
-]
-`;
-
-exports[`primitive types numeric type i8 1`] = `
-Uint8Array [
-  128,
-]
-`;
-
-exports[`primitive types numeric type i16 1`] = `
-Uint8Array [
-  0,
-  128,
-]
-`;
-
-exports[`primitive types numeric type i32 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types numeric type i64 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types numeric type i128 1`] = `
-Uint8Array [
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  0,
-  128,
-]
-`;
-
-exports[`primitive types numeric type f32 1`] = `
-Uint8Array [
-  0,
-  0,
-  128,
-  60,
-]
-`;
-
-exports[`primitive types numeric type f64 1`] = `
-Uint8Array [
-  24,
-  45,
-  68,
-  84,
-  251,
-  33,
-  9,
-  64,
-]
-`;
-
-exports[`primitive types bool 1`] = `
-Uint8Array [
-  1,
-]
-`;
-
-exports[`primitive types bool 2`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`primitive types string 1`] = `
-Uint8Array [
-  18,
-  0,
-  0,
-  0,
-  72,
-  101,
-  108,
-  108,
-  111,
-  44,
-  32,
-  119,
-  111,
-  114,
-  108,
-  100,
-  33,
-  32,
-  240,
-  159,
-  145,
-  139,
-]
-`;
-
-exports[`primitive types unit 1`] = `Uint8Array []`;
-
-exports[`complex types fixed array 1`] = `
-Uint8Array [
-  1,
-  0,
-  2,
-  0,
-  3,
-  0,
-]
-`;
-
-exports[`complex types dynamic vec 1`] = `
-Uint8Array [
-  5,
-  0,
-  0,
-  0,
-  1,
-  2,
-  3,
-  4,
-  5,
-]
-`;
-
-exports[`complex types option: some value 1`] = `
-Uint8Array [
-  1,
-  5,
-  0,
-  0,
-  0,
-  104,
-  101,
-  108,
-  108,
-  111,
-]
-`;
-
-exports[`complex types option: none value 1`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`complex types hashset 1`] = `
-Uint8Array [
-  3,
-  0,
-  0,
-  0,
-  1,
-  0,
-  0,
-  0,
-  97,
-  1,
-  0,
-  0,
-  0,
-  98,
-  1,
-  0,
-  0,
-  0,
-  99,
-]
-`;
-
-exports[`complex types hashmap 1`] = `
-Uint8Array [
-  2,
-  0,
-  0,
-  0,
-  5,
-  0,
-  0,
-  0,
-  97,
-  108,
-  105,
-  99,
-  101,
-  100,
-  0,
-  0,
-  0,
-  3,
-  0,
-  0,
-  0,
-  98,
-  111,
-  98,
-  200,
-  0,
-  0,
-  0,
-]
-`;
-
-exports[`complex types struct 1`] = `
-Uint8Array [
-  5,
-  0,
-  0,
-  0,
-  97,
-  108,
-  105,
-  99,
-  101,
-  25,
-  3,
-  0,
-  0,
-  0,
-  90,
-  0,
-  95,
-  0,
-  100,
-  0,
-]
-`;
-
-exports[`complex types enum: simple enum 1`] = `
-Uint8Array [
-  0,
-]
-`;
-
-exports[`complex types enum: enum with data - ok 1`] = `
-Uint8Array [
-  0,
-  7,
-  0,
-  0,
-  0,
-  115,
-  117,
-  99,
-  99,
-  101,
-  115,
-  115,
-]
-`;
-
-exports[`complex types enum: enum with data - err 1`] = `
-Uint8Array [
-  1,
-  148,
-  1,
-  9,
-  0,
-  0,
-  0,
-  78,
-  111,
-  116,
-  32,
-  102,
-  111,
-  117,
-  110,
-  100,
-]
-`;
-
-exports[`complex nested structures game state example 1`] = `
+exports[`complex nested structures > game state example 1`] = `
 Uint8Array [
   1,
   0,
@@ -465,3 +118,350 @@ Uint8Array [
   73,
 ]
 `;
+
+exports[`complex types > dynamic vec 1`] = `
+Uint8Array [
+  5,
+  0,
+  0,
+  0,
+  1,
+  2,
+  3,
+  4,
+  5,
+]
+`;
+
+exports[`complex types > enum > enum with data - err 1`] = `
+Uint8Array [
+  1,
+  148,
+  1,
+  9,
+  0,
+  0,
+  0,
+  78,
+  111,
+  116,
+  32,
+  102,
+  111,
+  117,
+  110,
+  100,
+]
+`;
+
+exports[`complex types > enum > enum with data - ok 1`] = `
+Uint8Array [
+  0,
+  7,
+  0,
+  0,
+  0,
+  115,
+  117,
+  99,
+  99,
+  101,
+  115,
+  115,
+]
+`;
+
+exports[`complex types > enum > simple enum 1`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`complex types > fixed array 1`] = `
+Uint8Array [
+  1,
+  0,
+  2,
+  0,
+  3,
+  0,
+]
+`;
+
+exports[`complex types > hashmap 1`] = `
+Uint8Array [
+  2,
+  0,
+  0,
+  0,
+  5,
+  0,
+  0,
+  0,
+  97,
+  108,
+  105,
+  99,
+  101,
+  100,
+  0,
+  0,
+  0,
+  3,
+  0,
+  0,
+  0,
+  98,
+  111,
+  98,
+  200,
+  0,
+  0,
+  0,
+]
+`;
+
+exports[`complex types > hashset 1`] = `
+Uint8Array [
+  3,
+  0,
+  0,
+  0,
+  1,
+  0,
+  0,
+  0,
+  97,
+  1,
+  0,
+  0,
+  0,
+  98,
+  1,
+  0,
+  0,
+  0,
+  99,
+]
+`;
+
+exports[`complex types > option > none value 1`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`complex types > option > some value 1`] = `
+Uint8Array [
+  1,
+  5,
+  0,
+  0,
+  0,
+  104,
+  101,
+  108,
+  108,
+  111,
+]
+`;
+
+exports[`complex types > struct 1`] = `
+Uint8Array [
+  5,
+  0,
+  0,
+  0,
+  97,
+  108,
+  105,
+  99,
+  101,
+  25,
+  3,
+  0,
+  0,
+  0,
+  90,
+  0,
+  95,
+  0,
+  100,
+  0,
+]
+`;
+
+exports[`primitive types > bool 1`] = `
+Uint8Array [
+  1,
+]
+`;
+
+exports[`primitive types > bool 2`] = `
+Uint8Array [
+  0,
+]
+`;
+
+exports[`primitive types > numeric type 'f32' 1`] = `
+Uint8Array [
+  0,
+  0,
+  128,
+  60,
+]
+`;
+
+exports[`primitive types > numeric type 'f64' 1`] = `
+Uint8Array [
+  24,
+  45,
+  68,
+  84,
+  251,
+  33,
+  9,
+  64,
+]
+`;
+
+exports[`primitive types > numeric type 'i8' 1`] = `
+Uint8Array [
+  128,
+]
+`;
+
+exports[`primitive types > numeric type 'i16' 1`] = `
+Uint8Array [
+  0,
+  128,
+]
+`;
+
+exports[`primitive types > numeric type 'i32' 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types > numeric type 'i64' 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types > numeric type 'i128' 1`] = `
+Uint8Array [
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  0,
+  128,
+]
+`;
+
+exports[`primitive types > numeric type 'u8' 1`] = `
+Uint8Array [
+  255,
+]
+`;
+
+exports[`primitive types > numeric type 'u16' 1`] = `
+Uint8Array [
+  255,
+  255,
+]
+`;
+
+exports[`primitive types > numeric type 'u32' 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types > numeric type 'u64' 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types > numeric type 'u128' 1`] = `
+Uint8Array [
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+  255,
+]
+`;
+
+exports[`primitive types > string 1`] = `
+Uint8Array [
+  18,
+  0,
+  0,
+  0,
+  72,
+  101,
+  108,
+  108,
+  111,
+  44,
+  32,
+  119,
+  111,
+  114,
+  108,
+  100,
+  33,
+  32,
+  240,
+  159,
+  145,
+  139,
+]
+`;
+
+exports[`primitive types > unit 1`] = `Uint8Array []`;

--- a/test/bytes.test.ts
+++ b/test/bytes.test.ts
@@ -13,7 +13,7 @@ describe("bytes helper", () => {
     expect(Array.from(decoded)).toEqual(Array.from(original))
 
     const vecSchema = b.vec(b.u8())
-    const vecEncoded = vecSchema.serialize(original)
+    const vecEncoded = vecSchema.serialize(Array.from(original))
 
     expect(encoded).toEqual(vecEncoded)
   })

--- a/test/coverage.test.ts
+++ b/test/coverage.test.ts
@@ -23,54 +23,54 @@ describe("Coverage - Missing Lines", () => {
     })
   })
 
-  describe("TypedArray Coverage", () => {
-    test("u32 vec returns Uint32Array", () => {
+  describe("Vec returns plain arrays", () => {
+    test("u32 vec returns number[]", () => {
       const schema = b.vec(b.u32())
-      const value = new Uint32Array([1, 2, 3, 4, 5])
+      const value = [1, 2, 3, 4, 5]
 
       const buffer = schema.serialize(value)
       const decoded = schema.deserialize(buffer)
-      expect(decoded).toBeInstanceOf(Uint32Array)
+      expect(Array.isArray(decoded)).toBe(true)
       expect(decoded).toEqual(value)
     })
 
-    test("i8 vec returns Int8Array", () => {
+    test("i8 vec returns number[]", () => {
       const schema = b.vec(b.i8())
-      const value = new Int8Array([-1, 2, -3, 4, -5])
+      const value = [-1, 2, -3, 4, -5]
 
       const buffer = schema.serialize(value)
       const decoded = schema.deserialize(buffer)
-      expect(decoded).toBeInstanceOf(Int8Array)
+      expect(Array.isArray(decoded)).toBe(true)
       expect(decoded).toEqual(value)
     })
 
-    test("i16 vec returns Int16Array", () => {
+    test("i16 vec returns number[]", () => {
       const schema = b.vec(b.i16())
-      const value = new Int16Array([-1000, 2000, -3000, 4000])
+      const value = [-1000, 2000, -3000, 4000]
 
       const buffer = schema.serialize(value)
       const decoded = schema.deserialize(buffer)
-      expect(decoded).toBeInstanceOf(Int16Array)
+      expect(Array.isArray(decoded)).toBe(true)
       expect(decoded).toEqual(value)
     })
 
-    test("i32 vec returns Int32Array", () => {
+    test("i32 vec returns number[]", () => {
       const schema = b.vec(b.i32())
-      const value = new Int32Array([-100000, 200000, -300000])
+      const value = [-100000, 200000, -300000]
 
       const buffer = schema.serialize(value)
       const decoded = schema.deserialize(buffer)
-      expect(decoded).toBeInstanceOf(Int32Array)
+      expect(Array.isArray(decoded)).toBe(true)
       expect(decoded).toEqual(value)
     })
 
-    test("f64 vec returns Float64Array", () => {
+    test("f64 vec returns number[]", () => {
       const schema = b.vec(b.f64())
-      const value = new Float64Array([1.1, 2.2, 3.3, 4.4, 5.5])
+      const value = [1.1, 2.2, 3.3, 4.4, 5.5]
 
       const buffer = schema.serialize(value)
       const decoded = schema.deserialize(buffer)
-      expect(decoded).toBeInstanceOf(Float64Array)
+      expect(Array.isArray(decoded)).toBe(true)
       expect(decoded).toEqual(value)
     })
   })

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -155,8 +155,8 @@ describe("Zorsh Edge Cases", () => {
       const setSchema = b.hashSet(b.string())
 
       // Empty collections
-      expect(vecSchema.deserialize(vecSchema.serialize(new Uint8Array([])))).toEqual(
-        new Uint8Array([]),
+      expect(vecSchema.deserialize(vecSchema.serialize([]))).toEqual(
+        [],
       )
       expect(mapSchema.deserialize(mapSchema.serialize(new Map()))).toEqual(new Map())
       expect(setSchema.deserialize(setSchema.serialize(new Set()))).toEqual(new Set())
@@ -174,9 +174,7 @@ describe("Zorsh Edge Cases", () => {
           .map((_, i) => `item${i}`),
       )
 
-      expect(vecSchema.deserialize(vecSchema.serialize(new Uint8Array(largeVec)))).toEqual(
-        new Uint8Array(largeVec),
-      )
+      expect(vecSchema.deserialize(vecSchema.serialize(largeVec))).toEqual(largeVec)
       expect(mapSchema.deserialize(mapSchema.serialize(new Map(largeMap)))).toEqual(largeMap)
       expect(setSchema.deserialize(setSchema.serialize(new Set(largeSet)))).toEqual(largeSet)
     })
@@ -185,12 +183,12 @@ describe("Zorsh Edge Cases", () => {
       const deepSchema = b.vec(b.vec(b.vec(b.vec(b.u8()))))
       const deep = [
         [
-          [new Uint8Array([1]), new Uint8Array([2])],
-          [new Uint8Array([3]), new Uint8Array([4])],
+          [[1], [2]],
+          [[3], [4]],
         ],
         [
-          [new Uint8Array([5]), new Uint8Array([6])],
-          [new Uint8Array([7]), new Uint8Array([8])],
+          [[5], [6]],
+          [[7], [8]],
         ],
       ]
 
@@ -208,11 +206,11 @@ describe("Zorsh Edge Cases", () => {
       )
 
       const map = new Map([
-        ["", { data: new Uint8Array([]), metadata: null, tags: new Set([]) }],
+        ["", { data: [], metadata: null, tags: new Set([]) }],
         [
           "key1",
           {
-            data: new Uint8Array([1, 2, 3]),
+            data: [1, 2, 3],
             metadata: "test",
             tags: new Set(["tag1", "tag2"]),
           },
@@ -276,12 +274,12 @@ describe("Zorsh Edge Cases", () => {
         { Empty: {} },
         { Single: 42 },
         { Nested: { A: "test" } },
-        { Nested: { B: new Uint8Array([1, 2, 3]) } },
+        { Nested: { B: [1, 2, 3] } },
         { Nested: { C: new Map([["key", 42]]) } },
         {
           Complex: {
             data: [null, "test", null],
-            metadata: new Map([["key", new Uint8Array([1, 2, 3])]]),
+            metadata: new Map([["key", [1, 2, 3]]]),
           },
         },
       ]
@@ -330,7 +328,7 @@ describe("Zorsh Edge Cases", () => {
         text: "Hello 🌍",
         floating: Number.POSITIVE_INFINITY,
         optional: null,
-        list: new Uint8Array([1, 2, 3]),
+        list: [1, 2, 3],
         mapping: new Map([
           ["key1", 42],
           ["key2", 43],

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -72,7 +72,7 @@ describe("complex types", () => {
 
   test("dynamic vec", () => {
     const schema = b.vec(b.u8())
-    const value = new Uint8Array([1, 2, 3, 4, 5])
+    const value = [1, 2, 3, 4, 5]
     const buffer = schema.serialize(value)
     expect(buffer).toMatchSnapshot()
     expect(schema.deserialize(buffer)).toEqual(value)
@@ -121,7 +121,7 @@ describe("complex types", () => {
     const value = {
       name: "alice",
       age: 25,
-      scores: new Uint16Array([90, 95, 100]),
+      scores: [90, 95, 100],
     }
 
     const buffer = schema.serialize(value)
@@ -193,7 +193,7 @@ describe("complex nested structures", () => {
             ]),
             achievements: new Set(["first_kill", "speedrun"]),
             guild: "Warriors",
-            recentScores: new Uint16Array([100, 95, 98]),
+            recentScores: [100, 95, 98],
           },
         ],
       ]),
@@ -227,7 +227,7 @@ describe("type inference", () => {
     const user: User = {
       name: "Alice",
       age: 25,
-      scores: new Uint16Array([100, 95, 98]),
+      scores: [100, 95, 98],
       metadata: {
         joinDate: BigInt(Date.now()),
         rank: "Gold",

--- a/test/tuples.test.ts
+++ b/test/tuples.test.ts
@@ -20,11 +20,11 @@ describe("tuple serialization", () => {
 
   it("handles tuples with complex types", () => {
     const schema = b.tuple(b.vec(b.u8()), b.option(b.string()), b.tuple(b.f32(), b.f32()))
-    const value: b.infer<typeof schema> = [new Uint8Array([1, 2, 3]), "optional", [1.5, 2.5]]
+    const value: b.infer<typeof schema> = [[1, 2, 3], "optional", [1.5, 2.5]]
     const bytes = schema.serialize(value)
     const decoded = schema.deserialize(bytes)
 
-    expect(decoded[0]).toBeInstanceOf(Uint8Array)
+    expect(Array.isArray(decoded[0])).toBe(true)
     expect(decoded[0]).toEqual(value[0])
     expect(decoded[1]).toEqual(value[1])
     expect(decoded[2]).toEqual(value[2])
@@ -91,7 +91,7 @@ describe("tuple serialization", () => {
   it("handles tuples with collections", () => {
     const schema = b.tuple(b.vec(b.u8()), b.hashSet(b.string()), b.hashMap(b.string(), b.u32()))
     const value: b.infer<typeof schema> = [
-      new Uint8Array([1, 2, 3]),
+      [1, 2, 3],
       new Set(["a", "b", "c"]),
       new Map([
         ["key1", 1],
@@ -102,7 +102,7 @@ describe("tuple serialization", () => {
     const decoded = schema.deserialize(bytes)
 
     // Check each component separately due to complex types
-    expect(decoded[0]).toBeInstanceOf(Uint8Array)
+    expect(Array.isArray(decoded[0])).toBe(true)
     expect(decoded[0]).toEqual(value[0])
     expect(decoded[1]).toEqual(value[1])
     expect(decoded[2]).toEqual(value[2])

--- a/test/typed-arrays.test.ts
+++ b/test/typed-arrays.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "vitest"
 import { b } from "../src/schema"
 
-describe("Vec with TypedArrays", () => {
-  test("u8 vec returns Uint8Array", () => {
+describe("Vec returns plain arrays", () => {
+  test("u8 vec returns number[]", () => {
     const schema = b.vec(b.u8())
-    const value = new Uint8Array([1, 2, 3, 4, 5])
+    const value = [1, 2, 3, 4, 5]
 
     // Type checking
-    type Expected = Uint8Array
+    type Expected = number[]
     type Actual = b.infer<typeof schema>
     // biome-ignore lint/correctness/noUnusedVariables: This is a test
     const typecheck: Expected = {} as Actual // Should compile
@@ -15,39 +15,39 @@ describe("Vec with TypedArrays", () => {
     // Runtime test
     const buffer = schema.serialize(value)
     const decoded = schema.deserialize(buffer)
-    expect(decoded).toBeInstanceOf(Uint8Array)
+    expect(Array.isArray(decoded)).toBe(true)
     expect(decoded).toEqual(value)
   })
 
-  test("u16 vec returns Uint16Array", () => {
+  test("u16 vec returns number[]", () => {
     const schema = b.vec(b.u16())
-    const value = new Uint16Array([1, 2, 3, 4, 5])
+    const value = [1, 2, 3, 4, 5]
 
     // Type checking
-    type Expected = Uint16Array
+    type Expected = number[]
     type Actual = b.infer<typeof schema>
     // biome-ignore lint/correctness/noUnusedVariables: This is a test
     const typecheck: Expected = {} as Actual // Should compile
 
     const buffer = schema.serialize(value)
     const decoded = schema.deserialize(buffer)
-    expect(decoded).toBeInstanceOf(Uint16Array)
+    expect(Array.isArray(decoded)).toBe(true)
     expect(decoded).toEqual(value)
   })
 
-  test("i64 vec returns BigInt64Array", () => {
+  test("i64 vec returns bigint[]", () => {
     const schema = b.vec(b.i64())
-    const value = new BigInt64Array([1n, 2n, 3n])
+    const value = [1n, 2n, 3n]
 
     // Type checking
-    type Expected = BigInt64Array
+    type Expected = bigint[]
     type Actual = b.infer<typeof schema>
     // biome-ignore lint/correctness/noUnusedVariables: This is a test
     const typecheck: Expected = {} as Actual // Should compile
 
     const buffer = schema.serialize(value)
     const decoded = schema.deserialize(buffer)
-    expect(decoded).toBeInstanceOf(BigInt64Array)
+    expect(Array.isArray(decoded)).toBe(true)
     expect(decoded).toEqual(value)
   })
 
@@ -67,28 +67,28 @@ describe("Vec with TypedArrays", () => {
     expect(decoded).toEqual(value)
   })
 
-  test("TypedArrays in complex structures", () => {
+  test("plain arrays in complex structures", () => {
     const PlayerSchema = b.struct({
       name: b.string(),
-      position: b.vec(b.f32()), // Should be Float32Array
-      inventory: b.vec(b.u8()), // Should be Uint8Array
-      scores: b.vec(b.u16()), // Should be Uint16Array
+      position: b.vec(b.f32()), // Should be number[]
+      inventory: b.vec(b.u8()), // Should be number[]
+      scores: b.vec(b.u16()), // Should be number[]
     })
 
     const value = {
       name: "Alice",
-      position: new Float32Array([1.1, 2.2, 3.3]),
-      inventory: new Uint8Array([1, 2, 3]),
-      scores: new Uint16Array([100, 200, 300]),
+      position: [1.100000023841858, 2.200000047683716, 3.299999952316284],
+      inventory: [1, 2, 3],
+      scores: [100, 200, 300],
     }
 
     // Type checking
     type Player = b.infer<typeof PlayerSchema>
     type Expected = {
       name: string
-      position: Float32Array
-      inventory: Uint8Array
-      scores: Uint16Array
+      position: number[]
+      inventory: number[]
+      scores: number[]
     }
     // biome-ignore lint/correctness/noUnusedVariables: This is a test
     const typecheck: Expected = {} as Player // Should compile
@@ -96,9 +96,9 @@ describe("Vec with TypedArrays", () => {
     const buffer = PlayerSchema.serialize(value)
     const decoded = PlayerSchema.deserialize(buffer)
 
-    expect(decoded.position).toBeInstanceOf(Float32Array)
-    expect(decoded.inventory).toBeInstanceOf(Uint8Array)
-    expect(decoded.scores).toBeInstanceOf(Uint16Array)
+    expect(Array.isArray(decoded.position)).toBe(true)
+    expect(Array.isArray(decoded.inventory)).toBe(true)
+    expect(Array.isArray(decoded.scores)).toBe(true)
     expect(decoded).toEqual(value)
   })
 })

--- a/test/typed-arrays.test.ts
+++ b/test/typed-arrays.test.ts
@@ -77,7 +77,7 @@ describe("Vec returns plain arrays", () => {
 
     const value = {
       name: "Alice",
-      position: [1.100000023841858, 2.200000047683716, 3.299999952316284],
+      position: [1.1, 2.2, 3.3].map((v) => new Float32Array([v])[0]),
       inventory: [1, 2, 3],
       scores: [100, 200, 300],
     }

--- a/test/typed-arrays.test.ts
+++ b/test/typed-arrays.test.ts
@@ -77,7 +77,7 @@ describe("Vec returns plain arrays", () => {
 
     const value = {
       name: "Alice",
-      position: [1.1, 2.2, 3.3].map((v) => new Float32Array([v])[0]),
+      position: Array.from(new Float32Array([1.1, 2.2, 3.3])),
       inventory: [1, 2, 3],
       scores: [100, 200, 300],
     }


### PR DESCRIPTION
## Summary

- `b.vec()` with numeric element types now returns `Array<number>` / `Array<bigint>` instead of typed arrays (`Uint8Array`, `Uint32Array`, etc.)
- Removes `TypedArrayMap`, `VecType` conditional mapping, and the switch block that converted to typed arrays at runtime
- `b.bytes()` is unchanged — still returns `Uint8Array` for raw binary data
- Wire format is unchanged, this is purely a JS representation change

**BREAKING CHANGE** — closes #56

## Test plan
- [x] All 97 existing tests pass with updated assertions
- [x] TypeScript type-checking passes (`tsc --noEmit`)
- [x] Snapshots updated (serialized bytes unchanged, confirming wire format compatibility)