### PR TITLE
chore: upgrade biome from 1.9.4 to 2.4.9

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -7,16 +7,14 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": ["dist", "rust/borsh_test", "package.json", "coverage"]
+    "includes": ["**", "!**/dist", "!**/rust/borsh_test", "!**/package.json", "!**/coverage"]
   },
   "formatter": {
     "enabled": true,
     "indentStyle": "space",
     "lineWidth": 100
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "ISC",
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",
-    "@biomejs/biome": "^1.9.4",
+    "@biomejs/biome": "^2.4.9",
     "@changesets/cli": "^2.27.12",
     "@types/bun": "^1.3.2",
     "@types/node": "^25.0.3",

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,5 +1,5 @@
 import { BinaryReader, BinaryWriter } from "./binary-io"
-import { type TypeRegistry, registry } from "./registry"
+import { registry, type TypeRegistry } from "./registry"
 import type { EnumLike, VecType } from "./types"
 
 export class Schema<T, Type extends string = string> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,9 +8,8 @@ export type VecType<T> = T extends Schema<unknown, string> ? Array<TypeOf<T>> : 
 /**
  * Extracts the inner type from a Schema
  */
-export type TypeOf<T extends Schema<unknown, string>> = T extends Schema<infer U, string>
-  ? U
-  : never
+export type TypeOf<T extends Schema<unknown, string>> =
+  T extends Schema<infer U, string> ? U : never
 
 /**
  * Represents a TypeScript enum type.

--- a/test/edge-cases.test.ts
+++ b/test/edge-cases.test.ts
@@ -1,7 +1,7 @@
 import * as fs from "node:fs"
 import * as path from "node:path"
 import { describe, expect, test } from "vitest"
-import { type Schema, b } from "../src/schema"
+import { b, type Schema } from "../src/schema"
 
 interface TestType<T> {
   schema: Schema<T>
@@ -155,9 +155,7 @@ describe("Zorsh Edge Cases", () => {
       const setSchema = b.hashSet(b.string())
 
       // Empty collections
-      expect(vecSchema.deserialize(vecSchema.serialize([]))).toEqual(
-        [],
-      )
+      expect(vecSchema.deserialize(vecSchema.serialize([]))).toEqual([])
       expect(mapSchema.deserialize(mapSchema.serialize(new Map()))).toEqual(new Map())
       expect(setSchema.deserialize(setSchema.serialize(new Set()))).toEqual(new Set())
 

--- a/test/rust/complex-schema.ts
+++ b/test/rust/complex-schema.ts
@@ -66,4 +66,4 @@ const GameStateSchema = b.struct({
 })
 type GameState = b.infer<typeof GameStateSchema>
 
-export { GameStateSchema, type GameState, PlayerSchema, type Player, ItemSchema, type Item }
+export { type GameState, GameStateSchema, type Item, ItemSchema, type Player, PlayerSchema }

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest"
-import { type Schema, b } from "../src/schema"
+import { b, type Schema } from "../src/schema"
 
 interface TestType<T> {
   schema: Schema<T>


### PR DESCRIPTION
## Summary
- Upgrades `@biomejs/biome` from 1.9.4 to 2.4.9 using `biome migrate --write`
- Migrates config: `files.ignore` → `files.includes` with negated globs, `organizeImports` → `assist`
- Applies new Biome 2.x formatting (import ordering, minor reformats)

## Test plan
- [x] `bun run lint` passes
- [x] `bun run typecheck` passes
- [x] `bun run test` — all 97 tests pass